### PR TITLE
Merge updated Drivetrain from 'Feature/teleop-velocity-drive' into 'development'

### DIFF
--- a/src/main/java/frc/robot/commands/drivetrain/DriveVelocity.java
+++ b/src/main/java/frc/robot/commands/drivetrain/DriveVelocity.java
@@ -38,7 +38,7 @@ public class DriveVelocity extends CommandBase {
   @Override
   public void execute() {
     // Drive with velocity PID from joystick
-    drivetrain.arcadeDriveVelocity(throttle.getAsDouble(), rotation.getAsDouble());
+    drivetrain.arcadeDriveVelocity(-throttle.getAsDouble(), rotation.getAsDouble());
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/hopper/sequences/Dispense/Step2Unload.java
+++ b/src/main/java/frc/robot/commands/hopper/sequences/Dispense/Step2Unload.java
@@ -39,7 +39,9 @@ public class Step2Unload extends CommandBase {
 
   // Called once the command ends or is interrupted.
   @Override
-  public void end(boolean interrupted) { }
+  public void end(boolean interrupted) {
+    hopper.setIntake(Intake.NEUTRAL);
+   }
 
   // Returns true when the command should end.
   @Override


### PR DESCRIPTION
This PR refactors the Drivetrain for simplicity and easier control. Note that velocity controlled driving does not currently work, but the rest of these changes are working and should be used going forward.

## Changes

- Fixes the Drivetrain Shuffleboard tab
- Adds odometers to the Shuffleboard
- Fixes the encoder implementation
- Does NOT finish implementing velocity controlled drive

## Resolves

- Resolves #44 
- Resolves #36 
- Resolves #25 
- Resolves #22
- Resolves #16 

## See Also

- #33 (Update docs)
- #28 (speedometer and odometer)
- #14 (Drivetrain velocity control)
